### PR TITLE
Updates the Regex to Be More Restrictive

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The names of each metadata column (metadata_partition, and metadata_1..metadata_
 - metadata_partition_name: The name of the metadata_partition column (for example: "outbreak").
 - metadata_1_header..metadata_8_header: The name of each individual metadata column (for example: "organism" or "source").
 
+Entries in the `metadata_partition` column in the sample sheet, as well as the name provided by the `metadata_partition_name` parameter, must contain only the following characters alphanumeric, `_`, `.`, and `-` characters.
+
+Entries in the metadata columns in the sample sheet (`metadata_1` through `metadata_8`), as well as the name provided by the metadata header parameters (`metadata_1_header` through `metadata_8_header`), may not contain newlines, tabs, `"`, `'`, `\`, `|`, `;`, `>`, or `<` characters.
+
 An example of the sample sheet is available in [tests/data/samplesheets/samplesheet.csv](tests/data/samplesheets/samplesheet.csv) and corresponding example metadata headers are available in [assets/parameters.yaml](assets/parameters.yaml).
 
 Furthermore, the structure of the sample sheet is programmatically defined in [assets/schema_input.json](assets/schema_input.json). Validation of the sample sheet is performed by [nf-validation](https://nextflow-io.github.io/nf-validation/).

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -18,7 +18,7 @@
                 "type": "string",
                 "format": "file-path",
                 "pattern": "^\\S+\\.mlst(\\.subtyping)?\\.json(\\.gz)?$",
-                "errorMessage": "MLST JSON file from locidex report, cannot contain spaces and must have the extension: '.mlst.json' or '.mlst.json.gz'."
+                "errorMessage": "MLST JSON file from locidex report. The file path cannot contain spaces and must have one of the following extensions: '.mlst.json', '.mlst.json.gz', '.mlst.subtyping.json', or '.mlst.subtyping.json.gz'."
             },
             "metadata_partition": {
                 "type": "string",

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -25,63 +25,63 @@
                 "meta": ["metadata_partition"],
                 "errorMessage": "Metadata column used to partition clusters. All samples with the same value in this column will be partitioned into the same group.",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[a-zA-Z0-9_.-]+$"
             },
             "metadata_1": {
                 "type": "string",
                 "meta": ["metadata_1"],
                 "errorMessage": "Metadata associated with the sample (metadata_1).",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_2": {
                 "type": "string",
                 "meta": ["metadata_2"],
                 "errorMessage": "Metadata associated with the sample (metadata_2).",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_3": {
                 "type": "string",
                 "meta": ["metadata_3"],
                 "errorMessage": "Metadata associated with the sample (metadata_3).",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_4": {
                 "type": "string",
                 "meta": ["metadata_4"],
                 "errorMessage": "Metadata associated with the sample (metadata_4).",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_5": {
                 "type": "string",
                 "meta": ["metadata_5"],
                 "errorMessage": "Metadata associated with the sample (metadata_5).",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_6": {
                 "type": "string",
                 "meta": ["metadata_6"],
                 "errorMessage": "Metadata associated with the sample (metadata_6).",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_7": {
                 "type": "string",
                 "meta": ["metadata_7"],
                 "errorMessage": "Metadata associated with the sample (metadata_7).",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_8": {
                 "type": "string",
                 "meta": ["metadata_8"],
                 "errorMessage": "Metadata associated with the sample (metadata_8).",
                 "default": "",
-                "pattern": "^[^\\n\\t\"]+$"
+                "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             }
         },
         "required": ["sample", "mlst_alleles", "metadata_partition"]

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -12,74 +12,74 @@
                 "pattern": "^\\S+$",
                 "meta": ["id"],
                 "unique": true,
-                "errorMessage": "Sample name must be provided and cannot contain spaces"
+                "errorMessage": "Sample name must be provided and cannot contain spaces."
             },
             "mlst_alleles": {
                 "type": "string",
                 "format": "file-path",
                 "pattern": "^\\S+\\.mlst(\\.subtyping)?\\.json(\\.gz)?$",
-                "errorMessage": "MLST JSON file from locidex report, cannot contain spaces and must have the extension: '.mlst.json' or '.mlst.json.gz'"
+                "errorMessage": "MLST JSON file from locidex report, cannot contain spaces and must have the extension: '.mlst.json' or '.mlst.json.gz'."
             },
             "metadata_partition": {
                 "type": "string",
                 "meta": ["metadata_partition"],
-                "errorMessage": "Metadata column used to partition clusters. All samples with the same value in this column will be partitioned into the same group.",
+                "errorMessage": "Metadata column used to partition clusters. Must contain only alphanumeric, underscore, period, and dash characters.",
                 "default": "",
                 "pattern": "^[a-zA-Z0-9_.-]+$"
             },
             "metadata_1": {
                 "type": "string",
                 "meta": ["metadata_1"],
-                "errorMessage": "Metadata associated with the sample (metadata_1).",
+                "errorMessage": "Metadata associated with the sample (metadata_1). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;><",
                 "default": "",
                 "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_2": {
                 "type": "string",
                 "meta": ["metadata_2"],
-                "errorMessage": "Metadata associated with the sample (metadata_2).",
+                "errorMessage": "Metadata associated with the sample (metadata_2). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;><",
                 "default": "",
                 "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_3": {
                 "type": "string",
                 "meta": ["metadata_3"],
-                "errorMessage": "Metadata associated with the sample (metadata_3).",
+                "errorMessage": "Metadata associated with the sample (metadata_3). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;><",
                 "default": "",
                 "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_4": {
                 "type": "string",
                 "meta": ["metadata_4"],
-                "errorMessage": "Metadata associated with the sample (metadata_4).",
+                "errorMessage": "Metadata associated with the sample (metadata_4). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;><",
                 "default": "",
                 "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_5": {
                 "type": "string",
                 "meta": ["metadata_5"],
-                "errorMessage": "Metadata associated with the sample (metadata_5).",
+                "errorMessage": "Metadata associated with the sample (metadata_5). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;><",
                 "default": "",
                 "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_6": {
                 "type": "string",
                 "meta": ["metadata_6"],
-                "errorMessage": "Metadata associated with the sample (metadata_6).",
+                "errorMessage": "Metadata associated with the sample (metadata_6). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;><",
                 "default": "",
                 "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_7": {
                 "type": "string",
                 "meta": ["metadata_7"],
-                "errorMessage": "Metadata associated with the sample (metadata_7).",
+                "errorMessage": "Metadata associated with the sample (metadata_7). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;><",
                 "default": "",
                 "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             },
             "metadata_8": {
                 "type": "string",
                 "meta": ["metadata_8"],
-                "errorMessage": "Metadata associated with the sample (metadata_8).",
+                "errorMessage": "Metadata associated with the sample (metadata_8). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;><",
                 "default": "",
                 "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
             }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -68,63 +68,63 @@
                     "type": "string",
                     "default": "outbreak",
                     "description": "The column used to partition clusters. All samples with the same value in this column will be partitioned into the same group.",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[a-zA-Z0-9_.-]+$"
                 },
                 "metadata_1_header": {
                     "type": "string",
                     "default": "metadata_1",
                     "description": "The header name of metadata column 1.",
                     "fa_icon": "far fa-sticky-note",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
                 },
                 "metadata_2_header": {
                     "type": "string",
                     "default": "metadata_2",
                     "description": "The header name of metadata column 2.",
                     "fa_icon": "far fa-sticky-note",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
                 },
                 "metadata_3_header": {
                     "type": "string",
                     "default": "metadata_3",
                     "description": "The header name of metadata column 3.",
                     "fa_icon": "far fa-sticky-note",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
                 },
                 "metadata_4_header": {
                     "type": "string",
                     "default": "metadata_4",
                     "description": "The header name of metadata column 4.",
                     "fa_icon": "far fa-sticky-note",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
                 },
                 "metadata_5_header": {
                     "type": "string",
                     "default": "metadata_5",
                     "description": "The header name of metadata column 5.",
                     "fa_icon": "far fa-sticky-note",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
                 },
                 "metadata_6_header": {
                     "type": "string",
                     "default": "metadata_6",
                     "description": "The header name of metadata column 6.",
                     "fa_icon": "far fa-sticky-note",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
                 },
                 "metadata_7_header": {
                     "type": "string",
                     "default": "metadata_7",
                     "description": "The header name of metadata column 7.",
                     "fa_icon": "far fa-sticky-note",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
                 },
                 "metadata_8_header": {
                     "type": "string",
                     "default": "metadata_8",
                     "description": "The header name of metadata column 8.",
                     "fa_icon": "far fa-sticky-note",
-                    "pattern": "^[^\\n\\t\"]+$"
+                    "pattern": "^[^\\n\\t\\\"\\'\\\\|;><]+$"
                 }
             },
             "fa_icon": "far fa-clipboard"

--- a/tests/data/samplesheets/samplesheet-bad-metadata_1.csv
+++ b/tests/data/samplesheets/samplesheet-bad-metadata_1.csv
@@ -1,0 +1,7 @@
+sample,mlst_alleles,metadata_partition,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+S1,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S1.mlst.json,1,"Escherichia coli|","EHEC/STEC","Canada","O157:H7",21,"2024/05/30","beef",true
+S2,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S2.mlst.json,1,"Escherichia coli","EHEC/STEC","The United States","O157:H7",55,"2024/05/21","milk",false
+S3,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S3.mlst.json,2,"Escherichia coli","EPEC","France","O125",14,"2024/04/30","cheese",true
+S4,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S4.mlst.json,2,"Escherichia coli","EPEC","France","O125",35,"2024/04/22","cheese",true
+S5,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S5.mlst.json,3,"Escherichia coli","EAEC","Canada","O126:H27",61,"2012/09/01","milk",false
+S6,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S6.mlst.json,unassociated,"Escherichia coli","EAEC","Canada","O111:H21",43,"2011/12/25","fruit",false

--- a/tests/data/samplesheets/samplesheet-bad-metadata_partition.csv
+++ b/tests/data/samplesheets/samplesheet-bad-metadata_partition.csv
@@ -1,0 +1,7 @@
+sample,mlst_alleles,metadata_partition,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+S1,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S1.mlst.json,1@,"Escherichia coli","EHEC/STEC","Canada","O157:H7",21,"2024/05/30","beef",true
+S2,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S2.mlst.json,1,"Escherichia coli","EHEC/STEC","The United States","O157:H7",55,"2024/05/21","milk",false
+S3,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S3.mlst.json,2,"Escherichia coli","EPEC","France","O125",14,"2024/04/30","cheese",true
+S4,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S4.mlst.json,2,"Escherichia coli","EPEC","France","O125",35,"2024/04/22","cheese",true
+S5,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S5.mlst.json,3,"Escherichia coli","EAEC","Canada","O126:H27",61,"2012/09/01","milk",false
+S6,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S6.mlst.json,unassociated,"Escherichia coli","EAEC","Canada","O111:H21",43,"2011/12/25","fruit",false

--- a/tests/modules/local/maptotsv/main.nf.test
+++ b/tests/modules/local/maptotsv/main.nf.test
@@ -424,7 +424,7 @@ nextflow_process {
             with(process.out) {
                 // check outputs
                 assert path(tsv_path[0]).exists()
-                assert nonempty_column_headers == []
+                assert nonempty_column_headers == [null]
 
                 // parse tsv file
                 def tsv_text = path(tsv_path[0]).readLines()
@@ -456,7 +456,7 @@ nextflow_process {
             with(process.out) {
                 // check outputs
                 assert path(tsv_path[0]).exists()
-                assert nonempty_column_headers == []
+                assert nonempty_column_headers == [null]
 
                 // parse tsv file
                 def tsv_text = path(tsv_path[0]).readLines()

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -121,4 +121,154 @@ nextflow_pipeline {
             assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\nS3\\t2\\tEscherichia coli\\tEPEC\\nS4\\t2\\tEscherichia coli\\tEPEC\\n")
         }
     }
+
+    test("bad metadata_partition_name"){
+        tag "bad_metadata_partition_name"
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet.csv"
+                outdir = "results"
+
+                metadata_partition_name = "bad;>"
+                metadata_1_header = "organism"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "special"
+            }
+        }
+
+        then {
+            assert workflow.failed
+            assert workflow.stderr.join("\n").contains("string [bad;>] does not match pattern")
+        }
+    }
+
+    test("bad metadata_1_header"){
+        tag "bad_metadata_1_header"
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet.csv"
+                outdir = "results"
+
+                metadata_partition_name = "outbreak"
+                metadata_1_header = "organism|"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "special"
+            }
+        }
+
+        then {
+            assert workflow.failed
+            assert workflow.stderr.join("\n").contains("string [organism|] does not match pattern")
+        }
+    }
+
+    test("bad metadata_8_header"){
+        tag "bad_metadata_8_header"
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet.csv"
+                outdir = "results"
+
+                metadata_partition_name = "outbreak"
+                metadata_1_header = "organism"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "spe>cial"
+            }
+        }
+
+        then {
+            assert workflow.failed
+            assert workflow.stderr.join("\n").contains("string [spe>cial] does not match pattern")
+        }
+    }
+
+    test("bad meta_partition entry"){
+        tag "bad_meta_partition_entry"
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-bad-metadata_partition.csv"
+                outdir = "results"
+
+                metadata_partition_name = "outbreak"
+                metadata_1_header = "organism"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "special"
+            }
+        }
+
+        then {
+            assert workflow.failed
+            assert workflow.stderr.join("\n").contains("Metadata column used to partition clusters. Must contain only alphanumeric, underscore, period, and dash characters. (1@)")
+        }
+    }
+
+    test("bad metadata_partition entry"){
+        tag "bad_metadata_partition_entry"
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-bad-metadata_partition.csv"
+                outdir = "results"
+
+                metadata_partition_name = "outbreak"
+                metadata_1_header = "organism"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "special"
+            }
+        }
+
+        then {
+            assert workflow.failed
+            assert workflow.stderr.join("\n").contains("metadata_partition: Metadata column used to partition clusters. Must contain only alphanumeric, underscore, period, and dash characters. (1@)")
+        }
+    }
+
+    test("bad metadata_1 entry"){
+        tag "bad_metadata_1_entry"
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-bad-metadata_1.csv"
+                outdir = "results"
+
+                metadata_partition_name = "outbreak"
+                metadata_1_header = "organism"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "special"
+            }
+        }
+
+        then {
+            assert workflow.failed
+            assert workflow.stderr.join("\n").contains("metadata_1: Metadata associated with the sample (metadata_1). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;>< (Escherichia coli|)")
+        }
+    }
 }


### PR DESCRIPTION
To be safe, I'm using the same regex for the column headers as the column values.

The partition column entries are executed directly on the command line and need to be very restricted:

`"^[a-zA-Z0-9_.-]+$"` -> only alphanumeric, `_`, `.`, and `-`.

The other metadata columns are trying to balance safety with the reality that people use a lot of different characters in metadata:

`"^[^\\n\\t\\\"\\'\\\\|;><]+$"` -> `^[^\n\t\"\'\\|;><]+$` -> not newline, tab, `"`, `'`, `\`, `|`, `;`, `>`, or `<`.

