### PR TITLE
Adds Input Assure

### DIFF
--- a/bin/input_assure.py
+++ b/bin/input_assure.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+import json
+import argparse
+import csv
+import gzip
+import sys
+
+
+def open_file(file_path, mode):
+    # Open a file based on the file extension
+    if file_path.endswith(".gz"):
+        return gzip.open(file_path, mode)
+    else:
+        return open(file_path, mode)
+
+
+def check_inputs(json_file, sample_id, address, output_error_file, output_json_file):
+    with open_file(json_file, "rt") as f:
+        json_data = json.load(f)
+
+    # Define a variable to store the match_status (True or False)
+    match_status = sample_id in json_data
+
+    # Initialize the error message
+    error_message = None
+
+    # Check for multiple keys in the JSON file and define error message
+    keys = list(json_data.keys())
+    original_key = keys[0] if keys else None
+
+    if len(keys) == 0:
+        error_message = f"{json_file} is completely empty!"
+        print(error_message)
+        sys.exit(1)
+    elif len(keys) > 1:
+        # Check if sample_id matches any key
+        if not match_status:
+            error_message = f"No key in the MLST JSON file ({json_file}) matches the specified sample ID '{sample_id}'. The first key '{original_key}' has been forcefully changed to '{sample_id}' and all other keys have been removed."
+            # Retain only the specified sample ID
+            json_data = {sample_id: json_data.pop(original_key)}
+        else:
+            error_message = f"MLST JSON file ({json_file}) contains multiple keys: {keys}. The MLST JSON file has been modified to retain only the '{sample_id}' entry"
+            # Remove all keys expect the one matching sample_id
+            json_data = {sample_id: json_data[sample_id]}
+    elif not match_status:
+        # Define error message based on meta.address (query or reference)
+        if address == "null":
+            error_message = f"Query {sample_id} ID and JSON key in {json_file} DO NOT MATCH. The '{original_key}' key in {json_file} has been forcefully changed to '{sample_id}': User should manually check input files to ensure correctness."
+        else:
+            error_message = f"Reference {sample_id} ID and JSON key in {json_file} DO NOT MATCH. The '{original_key}' key in {json_file} has been forcefully changed to '{sample_id}': User should manually check input files to ensure correctness."
+        # Update the JSON file with the new sample ID
+        json_data[sample_id] = json_data.pop(original_key)
+
+    # Write file containing relevant error messages
+    if error_message:
+        with open(output_error_file, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["sample", "JSON_key", "error_message"])
+            writer.writerow([sample_id, keys, error_message])
+
+    # Write the updated JSON data back to the original file
+    with gzip.open(output_json_file, "wt") as f:
+        json.dump(json_data, f, indent=4)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check sample inputs, force change if ID ≠ KEY, and generate an error report."
+    )
+    parser.add_argument("--input", help="Path to the mlst.json file.", required=True)
+    parser.add_argument(
+        "--sample_id", help="Sample ID to check in the JSON file.", required=True
+    )
+    parser.add_argument(
+        "--address", help="Address to use in the error message.", required=True
+    )
+    parser.add_argument(
+        "--output_error", help="Path to the error report file.", required=True
+    )
+    parser.add_argument(
+        "--output_json", help="Path to the MLST JSON file (gzipped).", required=True
+    )
+
+    args = parser.parse_args()
+
+    check_inputs(
+        args.input, args.sample_id, args.address, args.output_error, args.output_json
+    )

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -84,4 +84,8 @@ process {
             pattern: '*_versions.yml'
         ]
     }
+
+    withName: INPUT_ASSURE {
+        fair = true
+    }
 }

--- a/modules/local/input_assure/main.nf
+++ b/modules/local/input_assure/main.nf
@@ -1,0 +1,32 @@
+process INPUT_ASSURE {
+    tag "Assures Inputs are Consistent"
+    label 'process_single'
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.8.3' :
+        'biocontainers/python:3.8.3' }"
+
+    input:
+    tuple val(meta), path(mlst)
+
+    output:
+    tuple val(meta), path("${meta.id}.mlst.json.gz"),               emit: result
+    tuple val(meta), path("*_error_report.csv"), optional: true,    emit: error_report
+    path("versions.yml"),                                           emit: versions
+
+    script:
+
+    """
+    input_assure.py \\
+        --input ${mlst} \\
+        --sample_id ${meta.id} \\
+        --address ${meta.address} \\
+        --output_error ${meta.id}_error_report.csv \\
+        --output_json ${meta.id}.mlst.json.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/tests/data/arborator/mismatch/metadata.included.tsv
+++ b/tests/data/arborator/mismatch/metadata.included.tsv
@@ -1,0 +1,7 @@
+sample	outbreak	organism	subtype	country	serovar	age	date	source	special
+S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True
+MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False
+S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True
+S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	True
+S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	False
+S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	False

--- a/tests/data/metadata/mismatched-metadata.tsv
+++ b/tests/data/metadata/mismatched-metadata.tsv
@@ -1,0 +1,7 @@
+sample	outbreak	organism	subtype	country	serovar	age	date	source	special
+S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
+MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
+S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
+S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
+S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
+S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false

--- a/tests/data/profiles/mismatched_profiles.tsv
+++ b/tests/data/profiles/mismatched_profiles.tsv
@@ -1,0 +1,7 @@
+sample_id	locus_1	locus_2	locus_3	locus_4	locus_5	locus_6	locus_7
+S1	1	1	1	1	1	1	1
+MISMATCH	1	1	2	2	?	4	1
+S3	1	2	2	2	1	5	1
+S4	1	2	3	2	1	6	1
+S5	1	2	?	2	1	8	1
+S6	2	3	3	-	?	9	0

--- a/tests/data/samplesheets/samplesheet-id-mismatch.csv
+++ b/tests/data/samplesheets/samplesheet-id-mismatch.csv
@@ -1,0 +1,7 @@
+sample,mlst_alleles,metadata_partition,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+S1,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S1.mlst.json,1,"Escherichia coli","EHEC/STEC","Canada","O157:H7",21,"2024/05/30","beef",true
+MISMATCH,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S2.mlst.json,1,"Escherichia coli","EHEC/STEC","The United States","O157:H7",55,"2024/05/21","milk",false
+S3,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S3.mlst.json,2,"Escherichia coli","EPEC","France","O125",14,"2024/04/30","cheese",true
+S4,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S4.mlst.json,2,"Escherichia coli","EPEC","France","O125",35,"2024/04/22","cheese",true
+S5,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S5.mlst.json,3,"Escherichia coli","EAEC","Canada","O126:H27",61,"2012/09/01","milk",false
+S6,https://raw.githubusercontent.com/phac-nml/clustersplitter/dev/tests/data/profiles/S6.mlst.json,unassociated,"Escherichia coli","EAEC","Canada","O111:H21",43,"2011/12/25","fruit",false

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -365,4 +365,112 @@ nextflow_pipeline {
             assert workflow.stderr.join("\n").contains("metadata_1: Metadata associated with the sample (metadata_1). Cannot contain newlines, tabs, quotes, apostrophes, or any of the following characters: |;>< (Escherichia coli|)")
         }
     }
+
+    test("Small-scale test of full pipeline, ID mismatch"){
+        tag "id-mismatch"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-id-mismatch.csv"
+                outdir = "results"
+
+                metadata_partition_name = "outbreak"
+                metadata_1_header = "organism"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "special"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check merged profiles
+            def actual_profile_tsv = path("$launchDir/results/merged/profile.tsv")
+            def expected_profile_tsv = path("$baseDir/tests/data/profiles/mismatched_profiles.tsv")
+            assert actual_profile_tsv.text == expected_profile_tsv.text
+
+            // Check aggregated metadata
+            def actual_metadata = path("$launchDir/results/metadata/aggregated_data.tsv")
+            def expected_metadata = path("$baseDir/tests/data/metadata/mismatched-metadata.tsv")
+            assert actual_metadata.text == expected_metadata.text
+
+            // Check auto-built config file:
+            def actual_config = path("$launchDir/results/build/config.json")
+            def expected_config = path("$baseDir/tests/data/configs/autoconfig_samplesheet.json")
+            assert actual_config.text == expected_config.text
+
+            // Arborator outputs:
+            // NOTE: Arborator produces a (somewhat) non-deterministic cluster summary,
+            // so it's not possible to compare the entire output.
+            def actual_arborator_summary = path("$launchDir/results/arborator/cluster_summary.tsv")
+            assert actual_arborator_summary.text.contains("Outbreak Code\tOrganism\tSubtype\tCountry of Collection\tSerovar\tPatient Age (years)\tDate\tSource Type\tSpecial")
+            assert actual_arborator_summary.text.contains("1\tEscherichia coli\tEHEC/STEC\tCanada,The United States\tO157:H7\t21,55\t2024/05/21,2024/05/30\tbeef,milk\tFalse,True")
+
+            def actual_arborator_meta_included = path("$launchDir/results/arborator/metadata.included.tsv")
+            def expected_arborator_meta_included = path("$baseDir/tests/data/arborator/mismatch/metadata.included.tsv")
+            assert actual_arborator_meta_included.text == expected_arborator_meta_included.text
+
+            assert path("$launchDir/results/arborator/1_clusters.tsv").exists()
+            assert path("$launchDir/results/arborator/1_loci.summary.tsv").exists()
+            assert path("$launchDir/results/arborator/1_matrix.pq").exists()
+            assert path("$launchDir/results/arborator/1_matrix.tsv").exists()
+            assert path("$launchDir/results/arborator/1_metadata.tsv").exists()
+            assert path("$launchDir/results/arborator/1_outliers.tsv").exists()
+            assert path("$launchDir/results/arborator/1_profile.tsv").exists()
+            assert path("$launchDir/results/arborator/1_tree.nwk").exists()
+
+            assert path("$launchDir/results/arborator/2_clusters.tsv").exists()
+            assert path("$launchDir/results/arborator/2_loci.summary.tsv").exists()
+            assert path("$launchDir/results/arborator/2_matrix.pq").exists()
+            assert path("$launchDir/results/arborator/2_matrix.tsv").exists()
+            assert path("$launchDir/results/arborator/2_metadata.tsv").exists()
+            assert path("$launchDir/results/arborator/2_outliers.tsv").exists()
+            assert path("$launchDir/results/arborator/2_profile.tsv").exists()
+            assert path("$launchDir/results/arborator/2_tree.nwk").exists()
+
+            // Check that the ArborView output is created
+            def actual_arborview = path("$launchDir/results/arborview/1_arborview.html")
+            assert actual_arborview.exists()
+            assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nMISMATCH\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+
+            actual_arborview = path("$launchDir/results/arborview/2_arborview.html")
+            assert actual_arborview.exists()
+            assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+
+            // compare IRIDA Next JSON output
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global
+            def iridanext_samples = iridanext_json.files.samples
+            def iridanext_metadata = iridanext_json.metadata.samples
+
+            assert iridanext_global.findAll { it.path == "arborator/1_clusters.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_loci.summary.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_matrix.pq" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_matrix.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_metadata.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_outliers.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_tree.nwk" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_clusters.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_loci.summary.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_matrix.pq" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_matrix.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_metadata.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_outliers.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_tree.nwk" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/cluster_summary.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/metadata.excluded.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/metadata.included.tsv" }.size() == 1
+
+            assert iridanext_samples.isEmpty()
+            assert iridanext_metadata.isEmpty()
+        }
+    }
 }


### PR DESCRIPTION
Adds input_assure to the workflow: enforces consistent sample names between IDs in the sample sheet and IDs in the corresponding MLST JSON files.